### PR TITLE
Removed Broken HyperLink

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -10,8 +10,6 @@
 
 * [**Optional Patches**](#optional-patches)
 
-* [**Help needed for these points**](#help-needed-for-these-points)
-
 * [**Patching and Usage Instructions**](#instructions)
 
 * [**Credits**](#credits)


### PR DESCRIPTION
The link, (https://github.com/ShadowOne333/The-Legend-of-Zelda-Redux#help-needed-for-these-points), in the ReadMe doesn't lead to any section. This is because the section "Help need for these points:" was removed in e6f143941dd75f7076565a2edef614c106e37890.