### PR TITLE
Fix missing sound effect in game over menu

### DIFF
--- a/code/menus/menu_tweaks.asm
+++ b/code/menus/menu_tweaks.asm
@@ -1529,6 +1529,9 @@ game_over_menu_input:
 	and.b #$08
 	beq .down_cursor4
 
+	lda.b #$01	// Play sound (Shield Block)
+	sta.w $0604
+
 	dec.b $13		// Wrap
 	bpl .exit
 

--- a/others/MMC5/code/menus/menu_tweaks.asm
+++ b/others/MMC5/code/menus/menu_tweaks.asm
@@ -1529,6 +1529,9 @@ game_over_menu_input:
 	and.b #$08
 	beq .down_cursor4
 
+	lda.b #$01	// Play sound (Shield Block)
+	sta.w $0604
+
 	dec.b $13		// Wrap
 	bpl .exit
 


### PR DESCRIPTION
Currently, on the game over screen, only the down/select cursor movement plays a sound. This commit also adds sound when the cursor moves up.